### PR TITLE
fix: resorption bidon-ville fusion des repos

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -103,13 +103,12 @@ urls:
   - url: https://resorption-bidonvilles.beta.gouv.fr
     category: logement
     repositories: 
-      - MTES-MCT/action-bidonvilles
-      - MTES-MCT/action-bidonvilles-infra
+      - MTES-MCT/resorption-bidonvilles
       - MTES-MCT/resorption-bidonvilles-deploy
   - url: https://api.resorption-bidonvilles.beta.gouv.fr
     category: logement
     repositories: 
-      - MTES-MCT/action-bidonvilles-api
+      - MTES-MCT/resorption-bidonvilles
     tools:
       stats: false
   - url: https://sparte.beta.gouv.fr


### PR DESCRIPTION
Les repos Résorptions bidon-villes API et front ont fusionnés et le nom du repo résultant a changé.
Je propose ce correctif dans la limite de ma compréhension de la config de dashlord.