### PR TITLE
chore: filter out DISMISSED and CLOSED from dependabot alerts

### DIFF
--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -179,6 +179,7 @@ jobs:
           repositories: ${{ join(matrix.sites.repositories) }}
           maxAlerts: 20
           output: scans/dependabotalerts.json
+          states: OPEN
 
       - name: Code quality alerts
         continue-on-error: true


### PR DESCRIPTION
Cette PR fait suite à l'ajout de cette option dans https://github.com/MTES-MCT/dependabotalerts-action/pull/12 et permet de ne pas prendre en compte les alertes dependabot `DISMISSED` (et `CLOSED`, comme avant).