### PR TITLE
Replace Wikicarbone with Ecobalyse.

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -210,10 +210,10 @@ urls:
     tools:
       dependabot: false
       codescan: false
-  - url: https://wikicarbone.beta.gouv.fr
+  - url: https://ecobalyse.beta.gouv.fr
     category: energie
     repositories: 
-      - MTES-MCT/wikicarbone
+      - MTES-MCT/ecobalyse
   - url: https://zerologementvacant.beta.gouv.fr
     category: logement
     repositories: 


### PR DESCRIPTION
Wikicarbone has been renamed to Ecobalyse, and the previous URL now redirects to `ecobalyse.beta.gouv.fr`. Though for some reason this redirection comes with quite an heavy HTTP performance penalty: 

<img width="925" alt="image" src="https://user-images.githubusercontent.com/41547/169983973-8e5b3e76-1fd5-460d-bd60-de86e0082499.png">

So this patch updates the confirguration to use the new name and the new URL.

Ping @tristanrobert 