### PR TITLE
Mise à jour de camino sur dashlord

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -52,18 +52,17 @@ urls:
     category: mines
     betaId: camino
     repositories: 
-      - MTES-MCT/camino-ui
-      - MTES-MCT/camino-scripting
-      - MTES-MCT/camino-flux
+      - MTES-MCT/camino
       - MTES-MCT/camino-flux-QGIS
   - url: https://api.camino.beta.gouv.fr
     category: mines
     betaId: camino
     repositories: 
-      - MTES-MCT/camino-api
+      - MTES-MCT/camino
     tools:
       stats: false
-      declaration-a11y: true
+      declaration-a11y: false
+      lighthouse: false
   - url: https://carbure.beta.gouv.fr
     category: energie
     betaId: carbure


### PR DESCRIPTION
@tristanrobert on s'est rendu compte qu'on n'avait pas mis à jour notre passage en mono-repo ici. On en profite pour désactiver les tools "impossible" sur l'API (mentions-légales, accessibilité, ...)