### PR TITLE
Upgrade to github actions v4

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Website
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -25,7 +25,7 @@ jobs:
         uses: SocialGouv/dashlord-actions/report@v1
 
       # to save the generated report.json as artifact
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           path: report.json
           name: report

--- a/.github/workflows/scans.yml
+++ b/.github/workflows/scans.yml
@@ -35,7 +35,7 @@ jobs:
       sites: ${{ steps.init.outputs.sites }}
       config: ${{ steps.init.outputs.config }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - id: init
         uses: "SocialGouv/dashlord-actions/init@v1"
         with:
@@ -61,7 +61,7 @@ jobs:
       - run: |
           mkdir scans
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Les actions sont en échec depuis le 15 septembre à cause de l'utilisation de versions deprecated

https://github.com/MTES-MCT/dashlord/actions/workflows/report.yml