### PR TITLE
Mise à jour de l’URL Aquapreneur

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -332,7 +332,7 @@ urls:
     betaId: BoRiS
     repositories:
       - MTES-MCT/boris
-  - url: https://aquapreneur.beta.gouv.fr
+  - url: https://aquapreneur.beta.gouv.fr/ping
     betaId: aquaculteurs.marins
     repositories:
       - MTES-MCT/aquapreneur


### PR DESCRIPTION
…pour coller avec l’URL utilisée dans updown.