### PR TITLE
Émile (app) + ajout de Prelex

### DIFF
--- a/dashlord.yml
+++ b/dashlord.yml
@@ -318,10 +318,8 @@ urls:
     category: logement
     betaId: emile
     tools:
-      declaration-a11y: false
-      declaration-rgpd: false
-      budget_page: false
       stats: false
+      budget_page: false
       dependabot: false
       codescan: false
   - url: https://zerologementvacant.beta.gouv.fr
@@ -367,5 +365,7 @@ urls:
     category: amenagement
     tools:
       betagouv: false
+      stats: false
+      budget_page: false
       dependabot: false
       codescan: false

--- a/dashlord.yml
+++ b/dashlord.yml
@@ -314,7 +314,7 @@ urls:
     betaId: ecobalyse
     repositories: 
       - MTES-MCT/ecobalyse
-  - url: https://www.programme-emile.org/
+  - url: https://emile.beta.gouv.fr
     category: logement
     betaId: emile
     tools:
@@ -362,3 +362,10 @@ urls:
     betaId: pitchou
     repositories:
       - https://github.com/betagouv/pitchou
+  - url: https://prelex.beta.gouv.fr
+    title: Prelex
+    category: amenagement
+    tools:
+      betagouv: false
+      dependabot: false
+      codescan: false


### PR DESCRIPTION
## Changements

### Émile
Bascule de l'entrée `emile` de la vitrine vers l'application :
- `https://www.programme-emile.org/` → `https://emile.beta.gouv.fr`

L'app (Next.js + DSFR, déployée sur Scalingo) est la cible utile pour les audits dashlord. `betaId: emile`, `category: logement` et les overrides d'outils existants sont conservés (code hébergé sur la forge GitLab interministérielle → `dependabot`/`codescan` restent désactivés, pas de repo GitHub public).

### Prelex (nouveau)
- `url: https://prelex.beta.gouv.fr`
- `category: amenagement`
- Pas de `betaId` (pas de fiche `/startups/prelex.html` sur beta.gouv → `betagouv: false`)
- Pas de repo GitHub public → `dependabot: false`, `codescan: false`
- L'app redirige vers `/login` (appli derrière auth) : les audits public-facing porteront sur la page de connexion.

YAML validé (parse OK, 51 urls).
